### PR TITLE
Feat/validacao cpfcnpj

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ A diferença é que será possível usar os seguintes métodos de validação:
 
 * **`cpf`** - Valida se o campo é um CPF válido.
 
+* **`cpf_cnpj`** - Valida se o campo é um CPF ou CNPJ válido.
+
 * **`data`** - Valida se o campo é uma data no formato `DD/MM/YYYY`<sup>*</sup>. Por exemplo: `31/12/1969`.
 
 * **`formato_cnpj`** - Valida se o campo tem uma máscara de CNPJ correta (**`99.999.999/9999-99`**).

--- a/src/br-validator/Validator.php
+++ b/src/br-validator/Validator.php
@@ -154,6 +154,47 @@ class Validator extends BaseValidator
     }
 
     /**
+     * Valida se o CPF ou CNPJ é válido
+     *
+     * @param string $attribute
+     * @param string $value
+     * @return boolean
+     */
+
+     protected function validateCpfCnpj($attribute, $value)
+     {
+         // Remove caracteres não numéricos
+         $cleanedValue = preg_replace('/\D/', '', $value);
+ 
+         // Verifica se o valor é um CPF válido
+         if (strlen($cleanedValue) == 11) {
+             $cpf = $cleanedValue;
+ 
+             // Realiza a validação do CPF
+ 
+             if (!$this->validateCpf($attribute, $cpf)) {
+                 return false;
+             }
+         }
+         // Verifica se o valor é um CNPJ válido
+         elseif (strlen($cleanedValue) == 14) {
+             $cnpj = $cleanedValue;
+ 
+             // Realiza a validação do CNPJ
+ 
+             if (!$this->validateCnpj($attribute, $cnpj)) {
+                 return false;
+             }
+         }
+         // Valor inválido
+         else {
+             return false;
+         }
+ 
+         return true;
+     }
+
+    /**
     * Valida se o CNH é válido
     * @param string $attribute
     * @param string $value

--- a/src/br-validator/ValidatorProvider.php
+++ b/src/br-validator/ValidatorProvider.php
@@ -41,6 +41,7 @@ class ValidatorProvider extends ServiceProvider
             'cnh'              => 'O campo :attribute não é uma carteira nacional de habilitação válida',
             'cnpj'             => 'O campo :attribute não é um CNPJ válido',
             'cpf'              => 'O campo :attribute não é um CPF válido',
+            'cpf_cnpj'         => 'O campo :attribute não é um CPF ou CNPJ válido',
             'data'             => 'O campo :attribute não é uma data com formato válido',
             'formato_cnpj'     => 'O campo :attribute não possui o formato válido de CNPJ',
             'formato_cpf'      => 'O campo :attribute não possui o formato válido de CPF',

--- a/tests/TestValidator.php
+++ b/tests/TestValidator.php
@@ -174,6 +174,36 @@ class TestValidator extends Orchestra\Testbench\TestCase
         $this->assertTrue($incorrect->fails()); 
     }
 
+    
+    public function testCpfCnpj()
+    {
+    $validCpf = \Validator::make(
+        ['cpf_cnpj' => '094.050.986-59'],
+        ['cpf_cnpj' => 'cpf-cnpj']
+    );
+
+    $validCnpj = \Validator::make(
+        ['cpf_cnpj' => '53.084.587/0001-20'],
+        ['cpf_cnpj' => 'cpf-cnpj']
+    );
+
+    $invalidCpf = \Validator::make(
+        ['cpf_cnpj' => '99800-1926'],
+        ['cpf_cnpj' => 'cpf-cnpj']
+    );
+
+    $invalidCnpj = \Validator::make(
+        ['cpf_cnpj' => '51.084.587/0001-20'],
+        ['cpf_cnpj' => 'cpf-cnpj']
+    );
+
+    $this->assertTrue($validCpf->passes());
+    $this->assertTrue($validCnpj->passes());
+    $this->assertTrue($invalidCpf->fails());
+    $this->assertTrue($invalidCnpj->fails());
+    }
+
+    
     public function testCnh()
     {
         $correct = \Validator::make(


### PR DESCRIPTION
Criação de uma validação única para um campo que aceita tanto CPF quanto CNPJ, flexibilizando assim o uso da validação. Também foi criado o teste para esse validador. 
A motivação para essa atualização se deu por uma necessidade de validação do cpf e cnpj no mesmo campo em um projeto no qual estou trabalhando.